### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,8 +3,8 @@ name = "tagua-vm"
 version = "0.0.1"
 dependencies = [
  "libc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "llvm-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "llvm-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -27,22 +27,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "libc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "llvm-sys"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -56,26 +51,26 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.51"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/source/vm/engine.rs
+++ b/source/vm/engine.rs
@@ -123,7 +123,7 @@ impl Engine {
                 &mut engine_ref,
                 module.to_ref(),
                 &mut engine_options,
-                engine_options_size as u64,
+                engine_options_size as usize,
                 &mut engine_error
             );
         }


### PR DESCRIPTION
`llvm-sys` was using `libc ^0.1`, and `nom` with us were using `libc ^0.2`, so `libc` were present twice. Now with the last version of `llvm-sys`, everyone is using the same version of `libc`.
