### PR TITLE
Provide a Dockerfile to build a standard development image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:jessie
+
+ENV ARCH=x86_64-unknown-linux-gnu
+ENV RUST_RELEASE=1.9.0
+ENV LLVM_RELEASE=3.9
+ENV CARGO_RELEASE=nightly
+
+RUN echo "deb http://llvm.org/apt/jessie/ llvm-toolchain-jessie main" > /etc/apt/sources.list.d/llvm.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
+    apt-get update && \
+    apt-get install -y curl llvm-$LLVM_RELEASE vim gcc libssl-dev libedit-dev libstdc++-4.9-dev && \
+    find /usr/bin -executable -iname llvm* | xargs -n1 -I file echo ln -s file file | sed s/-$LLVM_RELEASE$// | bash
+
+RUN curl -sL https://static.rust-lang.org/dist/rust-$RUST_RELEASE-$ARCH.tar.gz | tar xvz -C /tmp && \
+    /tmp/rust-$RUST_RELEASE-$ARCH/install.sh && \
+    rm -rf /tmp/rust-$RUST_RELEASE-$ARCH
+
+RUN curl -sL https://static.rust-lang.org/cargo-dist/cargo-$CARGO_RELEASE-$ARCH.tar.gz | tar xvz -C /tmp && \
+    /tmp/cargo-$CARGO_RELEASE-$ARCH/install.sh && \
+    rm -rf /tmp/cargo-$CARGO_RELEASE-$ARCH
+
+RUN apt-get remove --purge -y curl && \
+    apt-get autoclean && apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+VOLUME /source
+WORKDIR /source

--- a/README.md
+++ b/README.md
@@ -101,6 +101,30 @@ $ cargo build
 $ ./target/debug/tvm --help
 ```
 
+### Using Docker
+
+If you don't want to install Rust and LLVM on your machine you can use Docker:
+It provides everything you will need to build, test and run Tagua VM.
+
+First, you will need to build the docker image:
+
+```sh
+$ docker build -t tagua-vm .
+```
+
+You will then be able to run a container from this image:
+
+```sh
+$ docker run --rm -it --name tagua-vm-dev -v `pwd`:/source` bash
+```
+
+You are now inside a fresh container. To see if everything is fine, you can
+start the test suite:
+
+```sh
+$ cargo test
+```
+
 ## Contributing
 
 Do whatever you want. Just respect the license and the other contributors. Your


### PR DESCRIPTION
This is a first step to ease the bootstrapping of a development environment for contributors and testers.

We provide a simple `Dockerfile` (based on Debian Jessie) with every tools needed to start working on Tagua VM. This includes:
- Rust 1.7.0,
- Cargo nightly
- LLVM 3.8,
- libraries required to compile the project

The image is quite big once built: about 960MB due to all the things we have to install in it.
### Going further

This is a starting point and it only targets maintainers/contributors. What we could also do is provide a production image (`tagua-vm/tagua-vm`)  containing the latest stable binary.

With this image, anyone could try Tagua VM with a simple command like:

``` sh
$ docker run --rm -it -v `pwd`:/source tagua-vm/tagua-vm add.php
```

I think such an image should not be tracked inside the source repository but in a dedicated one. Something like https://github.com/tagua-vm/docker for example.
