### PR TITLE
Make the build status badge clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tagua VM ![build status](https://api.travis-ci.org/tagua-vm/tagua-vm.svg)
+# Tagua VM [![build status](https://api.travis-ci.org/tagua-vm/tagua-vm.svg)](https://travis-ci.org/tagua-vm/tagua-vm)
 
 Tagua VM is an experimental [PHP](http://php.net/) Virtual Machine written with
 [the Rust language](https://www.rust-lang.org/) and [the LLVM Compiler


### PR DESCRIPTION
this allows to access Travis builds easily rather than accessing the badge image
