### PR TITLE
Parser: Implement string literals

### DIFF
--- a/source/language/parser/rules/literals.rs
+++ b/source/language/parser/rules/literals.rs
@@ -153,7 +153,7 @@ named!(
         call!(string_single_quoted)
 );
 
-pub fn string_single_quoted(input: &[u8]) -> IResult<&[u8], String> {
+fn string_single_quoted(input: &[u8]) -> IResult<&[u8], String> {
     let input_length = input.len();
 
     if input_length < 2 {

--- a/source/language/parser/rules/literals.rs
+++ b/source/language/parser/rules/literals.rs
@@ -153,7 +153,9 @@ fn string_single_quoted(input: &[u8]) -> IResult<&[u8], String> {
         return IResult::Error(Err::Code(ErrorKind::Custom(StringError::TooShort as u32)));
     }
 
-    if input[0] != '\'' as u8 {
+    if input[0] == 'b' as u8 && input[1] == '\'' as u8 {
+        return string_single_quoted(&input[1..]);
+    } else if input[0] != '\'' as u8 {
         return IResult::Error(Err::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32)));
     }
 
@@ -387,8 +389,23 @@ mod tests {
     }
 
     #[test]
+    fn case_string_single_quoted_escaped_many() {
+        assert_eq!(string(b"'\\'f\\oo\\\\bar'"), Done(&b""[..], String::from("'f\\oo\\bar")));
+    }
+
+    #[test]
     fn case_string_single_quoted_empty() {
         assert_eq!(string(b"''"), Done(&b""[..], String::new()));
+    }
+
+    #[test]
+    fn case_string_binary_single_quoted() {
+        assert_eq!(string(b"b'foobar'"), Done(&b""[..], String::from("foobar")));
+    }
+
+    #[test]
+    fn case_string_binary_single_quoted_escaped_many() {
+        assert_eq!(string(b"b'\\'f\\oo\\\\bar'"), Done(&b""[..], String::from("'f\\oo\\bar")));
     }
 
     #[test]

--- a/source/language/parser/rules/literals.rs
+++ b/source/language/parser/rules/literals.rs
@@ -467,7 +467,7 @@ mod tests {
 
     #[test]
     fn case_string_single_quoted_escaped_many() {
-        assert_eq!(string(b"'\\'f\\oo\\\\bar'"), Done(&b""[..], String::from("'f\\oo\\bar")));
+        assert_eq!(string(b"'\\'f\\oo\\\\bar\\\\'"), Done(&b""[..], String::from("'f\\oo\\bar\\")));
     }
 
     #[test]

--- a/source/language/parser/rules/literals.rs
+++ b/source/language/parser/rules/literals.rs
@@ -149,7 +149,7 @@ pub enum StringError {
 }
 
 fn string_single_quoted(input: &[u8]) -> IResult<&[u8], String> {
-    if input.len() <= 2 {
+    if input.len() <= 1 {
         return IResult::Error(Err::Code(ErrorKind::Custom(StringError::TooShort as u32)));
     }
 
@@ -384,6 +384,11 @@ mod tests {
     #[test]
     fn case_string_single_quoted_escaped_any() {
         assert_eq!(string(b"'foo\\nbar'"), Done(&b""[..], String::from("foo\\nbar")));
+    }
+
+    #[test]
+    fn case_string_single_quoted_empty() {
+        assert_eq!(string(b"''"), Done(&b""[..], String::new()));
     }
 
     #[test]

--- a/source/language/parser/rules/literals.rs
+++ b/source/language/parser/rules/literals.rs
@@ -135,20 +135,25 @@ named!(
     )
 );
 
-named!(
-    pub string<String>,
-    call!(string_single_quoted)
-);
-
+/// String errors.
 #[derive(Debug)]
 pub enum StringError {
+    /// The datum starts as a string but is too short to be a string.
     TooShort,
+    /// The string open character is not correct.
     InvalidOpeningCharacter,
+    /// The string close character is not correct.
     InvalidClosingCharacter,
+    /// The string is not correctly encoded (expect UTF-8).
     InvalidEncoding
 }
 
-fn string_single_quoted(input: &[u8]) -> IResult<&[u8], String> {
+named!(
+    pub string<String>,
+        call!(string_single_quoted)
+);
+
+pub fn string_single_quoted(input: &[u8]) -> IResult<&[u8], String> {
     let input_length = input.len();
 
     if input_length < 2 {

--- a/source/language/parser/rules/literals.rs
+++ b/source/language/parser/rules/literals.rs
@@ -34,7 +34,13 @@
 //! The list of all literals is provided by the PHP Language Specification in the [Grammar chapter,
 //! Literals section](https://github.com/php/php-langspec/blob/master/spec/19-grammar.md#literals).
 
-use nom::{oct_digit, hex_digit};
+use nom::{
+    Err,
+    ErrorKind,
+    IResult,
+    hex_digit,
+    oct_digit
+};
 use std::str;
 use std::str::FromStr;
 
@@ -130,6 +136,69 @@ named!(
 );
 
 named!(
+    pub string<String>,
+    call!(string_single_quoted)
+);
+
+#[derive(Debug)]
+pub enum StringError {
+    TooShort,
+    InvalidOpeningCharacter,
+    InvalidClosingCharacter,
+    InvalidEncoding
+}
+
+fn string_single_quoted(input: &[u8]) -> IResult<&[u8], String> {
+    if input.len() <= 2 {
+        return IResult::Error(Err::Code(ErrorKind::Custom(StringError::TooShort as u32)));
+    }
+
+    if input[0] != '\'' as u8 {
+        return IResult::Error(Err::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32)));
+    }
+
+    let mut output   = String::new();
+    let mut offset   = 1;
+    let mut iterator = input[offset..].iter().enumerate();
+
+    while let Some((index, item)) = iterator.next() {
+        if *item == '\\' as u8 {
+            if let Some((next_index, next_item)) = iterator.next() {
+                if *next_item == '\'' as u8 ||
+                   *next_item == '\\' as u8 {
+                    match str::from_utf8(&input[offset..index + 1]) {
+                        Ok(output_tail) => {
+                            output.push_str(output_tail);
+                            offset = next_index + 1;
+                        },
+
+                        Err(_) => {
+                            return IResult::Error(Err::Code(ErrorKind::Custom(StringError::InvalidEncoding as u32)));
+                        }
+                    }
+                }
+            } else {
+                return IResult::Error(Err::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32)));
+            }
+        } else if *item == '\'' as u8 {
+            match str::from_utf8(&input[offset..index + 1]) {
+                Ok(output_tail) => {
+                    output.push_str(output_tail);
+
+                    return IResult::Done(&input[index + 2..], output);
+                },
+
+                Err(_) => {
+                    return IResult::Error(Err::Code(ErrorKind::Custom(StringError::InvalidEncoding as u32)));
+                }
+            }
+        }
+    }
+
+    IResult::Error(Err::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32)))
+}
+
+named!(
     pub identifier,
     re_bytes_find_static!(r"^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*")
 );
@@ -140,14 +209,16 @@ mod tests {
     use nom::IResult::{Done, Error};
     use nom::{Err, ErrorKind};
     use super::{
-        null,
-        boolean,
+        StringError,
         binary,
-        octal,
+        boolean,
         decimal,
-        hexadecimal,
         exponential,
-        identifier
+        hexadecimal,
+        identifier,
+        null,
+        octal,
+        string
     };
 
     #[test]
@@ -293,6 +364,46 @@ mod tests {
     #[test]
     fn case_invalid_exponential_only_the_dot() {
         assert_eq!(exponential(b"."), Error(Err::Code(ErrorKind::RegexpFind)));
+    }
+
+    #[test]
+    fn case_string_single_quoted() {
+        assert_eq!(string(b"'foobar'"), Done(&b""[..], String::from("foobar")));
+    }
+
+    #[test]
+    fn case_string_single_quoted_escaped_quote() {
+        assert_eq!(string(b"'foo\\'bar'"), Done(&b""[..], String::from("foo'bar")));
+    }
+
+    #[test]
+    fn case_string_single_quoted_escaped_backslash() {
+        assert_eq!(string(b"'foo\\\\bar'"), Done(&b""[..], String::from("foo\\bar")));
+    }
+
+    #[test]
+    fn case_string_single_quoted_escaped_any() {
+        assert_eq!(string(b"'foo\\nbar'"), Done(&b""[..], String::from("foo\\nbar")));
+    }
+
+    #[test]
+    fn case_invalid_string_single_quoted_too_short() {
+        assert_eq!(string(b"'"), Error(Err::Code(ErrorKind::Custom(StringError::TooShort as u32))));
+    }
+
+    #[test]
+    fn case_invalid_string_single_quoted_opening_character() {
+        assert_eq!(string(b"foobar'"), Error(Err::Code(ErrorKind::Custom(StringError::InvalidOpeningCharacter as u32))));
+    }
+
+    #[test]
+    fn case_invalid_string_single_quoted_closing_character() {
+        assert_eq!(string(b"'foobar"), Error(Err::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32))));
+    }
+
+    #[test]
+    fn case_invalid_string_single_quoted_closing_character_is_a_backslash() {
+        assert_eq!(string(b"'foobar\\"), Error(Err::Code(ErrorKind::Custom(StringError::InvalidClosingCharacter as u32))));
     }
 
     #[test]


### PR DESCRIPTION
Address https://github.com/tagua-vm/tagua-vm/issues/23.
### Specification

https://github.com/php/php-langspec/blob/master/spec/19-grammar.md#string-literals.
### Progression
- [x] Single-quoted string,
- [x] Binary single-quoted string,
- [ ] Double-quoted string (optional, postponed, see #33),
- [x] NowDoc string,
- [ ] HereDoc string (optional, postponed, see #33).
