### PR TITLE
Quality: Test against Rust 1.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 rust:
   - 1.7.0
+  - 1.8.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
Fix #34.

Update the `.travis.yml` configuration file to test Rust 1.8.
