### PR TITLE
Quality: Add Rust 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 rust:
   - 1.9.0
+  - 1.10.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
Fix https://github.com/tagua-vm/tagua-vm/issues/60.

Rust 1.11 has been released (https://blog.rust-lang.org/2016/08/18/Rust-1.11.html). One more version to support 😄.
